### PR TITLE
revised the return value of filter_pipeline to match its definition

### DIFF
--- a/fftools/ffmpeg.c
+++ b/fftools/ffmpeg.c
@@ -2413,7 +2413,7 @@ static void *filter_pipeline(void *arg)
         if (ret < 0)
             break;
     }
-    return;
+    return NULL;
 }
 #endif
 static int send_frame_to_filters(InputStream *ist, AVFrame *decoded_frame)


### PR DESCRIPTION
The return value of function 'filter_pipeline' is inconsistent with its definition. It will lead to a compile error in the newest version of gcc(9.2.0).